### PR TITLE
docs: Add Nix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ With your favourite aurhelper for example [yay](https://github.com/Jguer/yay) :
 yay -S raffi-bin
 ```
 
+### [NixOS / Nix](https://nixos.org) (unstable)
+
+```shell
+nix-shell -p raffi
+```
+
 ## Usage
 
 You can launch it directly and it will run the binary and args as defined in the [configuration](#configuration).


### PR DESCRIPTION
`raffi` is now packaged in NixOS / Nix. It's currently in the `unstable` channel. It will likely make it to the next stable release when that rolls around (my guess is November).

https://search.nixos.org/packages?channel=unstable&show=raffi&sort=relevance&type=packages&query=raffi