### PR TITLE
tests: avoid PATH-dependent firefox binary in config parsing tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -729,9 +729,9 @@ mod tests {
     #[test]
     fn test_read_config_from_reader() {
         let yaml_config = r#"
-        firefox:
-          binary: firefox
-          description: "Firefox browser"
+        shell:
+          binary: sh
+          description: "Shell"
         hello_script:
           script: "echo hello"
           description: "Hello script"
@@ -758,8 +758,8 @@ mod tests {
 
         let expected_configs = vec![
             RaffiConfig {
-                binary: Some("firefox".to_string()),
-                description: Some("Firefox browser".to_string()),
+                binary: Some("sh".to_string()),
+                description: Some("Shell".to_string()),
                 ..Default::default()
             },
             RaffiConfig {
@@ -783,9 +783,9 @@ mod tests {
             currencies: ["USD", "EUR", "GBP"]
           calculator:
             enabled: false
-        firefox:
-          binary: firefox
-          description: "Firefox browser"
+        shell:
+          binary: sh
+          description: "Shell"
         "#;
         let reader = Cursor::new(yaml_config);
         let args = Args {
@@ -899,9 +899,9 @@ mod tests {
               keyword: "tz"
               command: "batz"
               args: ["-j"]
-        firefox:
-          binary: firefox
-          description: "Firefox browser"
+        shell:
+          binary: sh
+          description: "Shell"
         "#;
         let reader = Cursor::new(yaml_config);
         let args = Args {
@@ -1070,9 +1070,9 @@ mod tests {
           ui_type: native
           default_script_shell: zsh
           no_icons: true
-        firefox:
-          binary: firefox
-          description: "Firefox browser"
+        shell:
+          binary: sh
+          description: "Shell"
         "#;
         let reader = Cursor::new(yaml_config);
         let args = Args {
@@ -1101,9 +1101,9 @@ mod tests {
     #[test]
     fn test_config_without_general_section() {
         let yaml_config = r#"
-        firefox:
-          binary: firefox
-          description: "Firefox browser"
+        shell:
+          binary: sh
+          description: "Shell"
         "#;
         let reader = Cursor::new(yaml_config);
         let args = Args {
@@ -1131,9 +1131,9 @@ mod tests {
         let yaml_config = r#"
         general:
           no_icons: true
-        firefox:
-          binary: firefox
-          description: "Firefox browser"
+        shell:
+          binary: sh
+          description: "Shell"
         "#;
         let reader = Cursor::new(yaml_config);
         let args = Args {
@@ -1161,9 +1161,9 @@ mod tests {
         let yaml_config = r#"
         general:
           theme: light
-        firefox:
-          binary: firefox
-          description: "Firefox browser"
+        shell:
+          binary: sh
+          description: "Shell"
         "#;
         let reader = Cursor::new(yaml_config);
         let args = Args {
@@ -1216,9 +1216,9 @@ mod tests {
             - name: "DuckDuckGo"
               keyword: "ddg"
               url: "https://duckduckgo.com/?q={query}"
-        firefox:
-          binary: firefox
-          description: "Firefox browser"
+        shell:
+          binary: sh
+          description: "Shell"
         "#;
         let reader = Cursor::new(yaml_config);
         let args = Args {


### PR DESCRIPTION
### Motivation
- Several config parsing tests filtered out entries in sandboxed builds because `DefaultBinaryChecker` checked for `firefox` in `$PATH`, which is not guaranteed to exist in build sandboxes.
- The goal is to make the parsing tests deterministic and independent of the host environment's `PATH` contents.

### Description
- Replaced `firefox` fixtures with a `shell` entry using `binary: sh` and `description: "Shell"` across parsing-related tests in `src/lib.rs` so the tests reference a binary that is reliably present.
- Updated `test_read_config_from_reader` expected `RaffiConfig` values to expect `binary: Some("sh")` and `description: Some("Shell")` instead of `firefox` values.
- Kept test intent unchanged (still asserting parsing of entries, addons, and general configuration) while removing environment dependency.
- Committed the change with message: `tests: avoid firefox dependency in config fixtures`.

### Testing
- Ran `make test` which executed the test suite and reported `40 passed; 0 failed`.
- Ran `make clippy` which completed without warnings (clippy passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992f0af48ec832d880ecc785dc534f8)